### PR TITLE
"GetChatHistory.get_chat_history() got an unexpected keyword argument 'reverse'

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -311,7 +311,7 @@ async def begin_import(config: dict, pagination_limit: int) -> dict:
     await client.start()
     last_read_message_id: int = config["last_read_message_id"]
     messages_iter = client.get_chat_history(
-        config["chat_id"], offset_id=last_read_message_id, reverse=True
+        config["chat_id"], offset_id=last_read_message_id
     )
     messages_list: list = []
     pagination_count: int = 0


### PR DESCRIPTION
encountered an issue with the Telegram Media Downloader program, which returned the error message "GetChatHistory.get_chat_history() got an unexpected keyword argument 'reverse'."  I was able to resolve the issue by removing `reverse: true` from my code. This solution was effective, and the program is now functioning properly.
![image](https://github.com/Tusharvoid/telegram_media_downloader/assets/70802073/7bf1ef75-5e07-4b7d-9cc4-360a6aeaae22)
